### PR TITLE
added city-page details

### DIFF
--- a/src/components/city-search.tsx
+++ b/src/components/city-search.tsx
@@ -1,90 +1,147 @@
-import React, { useState } from 'react'
-import { Button } from './ui/button'
-import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from './ui/command'
-import { Loader2, Search } from 'lucide-react';
-import { useLocationSearch } from '@/hooks/use-weather';
-import {  useNavigate } from 'react-router-dom';
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "./ui/command";
+import { Clock, Loader2, Search, XCircle } from "lucide-react";
+import { useLocationSearch } from "@/hooks/use-weather";
+import { useNavigate } from "react-router-dom";
+import { useSearchHistory , } from "../hooks/use-search-history";
+import { format } from "date-fns";
 
 const CitySearch = () => {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
 
- const {data : locations,  isLoading} =  useLocationSearch(query);
- const handleSelect = (cityData : string) => {
-  const [ lat, lon, name, country] = cityData.split("|");
+  const { data: locations, isLoading } = useLocationSearch(query);
+  const { history, clearHistory, addToHistory } = useSearchHistory();
 
+  const handleSelect = (cityData: string) => {
+    const [lat, lon, name, country] = cityData.split("|");
 
-  // add to search history
-  setOpen(false)
-  navigate(`/city/${name}??lat=${lat}&lon=${lon}`)
- };
- console.log(locations);
- 
+    // add to search history
+    addToHistory.mutate({
+      query,
+      name,
+      lat: parseFloat(lat),
+      lon: parseFloat(lon),
+      country,
+    });
+
+    setOpen(false);
+    navigate(`/city/${name}?lat=${lat}&lon=${lon}`);
+  };
+  console.log(locations);
+
   return (
     <>
-<Button 
-variant="outline" 
-className='relative w-full justify-start text-sm text-muted-foreground sm:pr-12 md:w-40 lg:w-64'
-onClick= {() => setOpen(true)} >
-<Search className="mr-2 h-4 w-4"/>
- Search cities...    </Button>
+      <Button
+        variant="outline"
+        className="relative w-full justify-start text-sm text-muted-foreground sm:pr-12 md:w-40 lg:w-64"
+        onClick={() => setOpen(true)}
+      >
+        <Search className="mr-2 h-4 w-4" />
+        Search cities...{" "}
+      </Button>
 
-    <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Search citiess..."
-      value={query}
-      onValueChange={setQuery}
-      />
-      <CommandList>
-        {query.length > 2 && !isLoading && (
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput
+          placeholder="Search citiess..."
+          value={query}
+          onValueChange={setQuery}
+        />
+        <CommandList>
+          {query.length > 2 && !isLoading && (
             <CommandEmpty>No results found.</CommandEmpty>
-        )}
-      
-        <CommandGroup heading="Favourites">
-          <CommandItem>Calculator</CommandItem>
-        </CommandGroup> 
-
-        <CommandSeparator/>
-
-        <CommandGroup heading="Recent Searches">
-          <CommandItem>Calculator</CommandItem>
-        </CommandGroup> 
-
-                <CommandSeparator/>
-        {locations && locations.length > 0 && (
-           <CommandGroup heading="Suggections">
-            {isLoading && (
-              <div className='flex items-center justify-center p-4'>
-                <Loader2 className='h-4 w-4 animate-spin'/>
-
-              </div>
-            )}
-            {locations.map((location) => {
-              return (
-          <CommandItem
-          key={ `${location.lat} - ${location.lon}`}
-          value={`${location.lat} | ${location.lon} | ${location.name} | ${location.country} `}
-          onSelect={handleSelect} >
-            <Search className='mr-2 h-4 w-4'/>
-          <span>{location.name}</span>
-          {location.state && (
-            <span className='text-sm text-muted-foreground'>
-              , {location.state}
-
-            </span>
           )}
-          <span className='text-sm text-muted-foreground'> , {location.country}</span>
-          </CommandItem>
 
-              )
-            })}
-        </CommandGroup>
-        )}
-       
-      </CommandList>
-    </CommandDialog>
+          <CommandGroup heading="Favourites">
+            <CommandItem></CommandItem>
+          </CommandGroup>
+
+
+          {history.length > 0 && (
+            <>
+              <CommandSeparator />
+              <CommandGroup>
+                <div className="flex items-center justify-between px-2 my-2">
+                  <p>Recent Searches</p>
+                  <Button variant="ghost"
+                  size="sm"
+                  onClick={() => clearHistory.mutate()}>
+                    <XCircle className="h-4 w-4" />
+                    Clear
+                  </Button>
+                </div>
+                {history.map((location ) => {
+                  return   <CommandItem
+                    key={`${location.lat} - ${location.lon}`}
+                    value={`${location.lat} | ${location.lon} | ${location.name} | ${location.country} `}
+                    onSelect={handleSelect}
+                  >
+                    <Clock className="mr-2 h-4 w-4" />
+                    <span>{location.name}</span>
+                    {location.state && (
+                      <span className="text-sm text-muted-foreground">
+                        , {location.state}
+                      </span>
+                    )}
+                    <span className="text-sm text-muted-foreground">
+                      {" "}
+                      , {location.country}
+                    </span>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {format(location.searchedAt, "MMM d, h:mm a")}
+
+                    </span>
+                  </CommandItem>
+                })}
+               
+              </CommandGroup>
+            </>
+          )}
+          <CommandSeparator />
+          {locations && locations.length > 0 && (
+            <CommandGroup heading="Suggections">
+              {isLoading && (
+                <div className="flex items-center justify-center p-4">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                </div>
+              )}
+              {locations.map((location) => {
+                return (
+                  <CommandItem
+                    key={`${location.lat} - ${location.lon}`}
+                    value={`${location.lat} | ${location.lon} | ${location.name} | ${location.country} `}
+                    onSelect={handleSelect}
+                  >
+                    <Search className="mr-2 h-4 w-4" />
+                    <span>{location.name}</span>
+                    {location.state && (
+                      <span className="text-sm text-muted-foreground">
+                        , {location.state}
+                      </span>
+                    )}
+                    <span className="text-sm text-muted-foreground">
+                      {" "}
+                      , {location.country}
+                    </span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </CommandDialog>
     </>
-  )
-}
+  );
+};
 
-export default CitySearch
+export default CitySearch;

--- a/src/hooks/use-favorite.tsx
+++ b/src/hooks/use-favorite.tsx
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useLocalStorege } from "./use-local-storage";
+import { Search } from "lucide-react";
+
+interface FavoriteCity {
+    id: string;
+    name: string;
+    lat: number;
+    lon: number;
+    country: string;
+    state?: string;
+    addedAt: number;
+}
+
+export function useSearchHistory() {
+   const [favorites, setFavorites] =  useLocalStorege<FavoriteCity[]>("search-history", []);
+
+   const favoritesQuery =  useQuery({
+    queryKey: ["favorites"],
+    queryFn: () => favorites,
+    initialData: favorites,
+    staleTime: Infinity, 
+   });
+
+
+   const queryClient = useQueryClient();
+   const addFavorites = useMutation( {
+        mutationFn: async (
+            city: Omit<FavoriteCity, "id" | "addedAt" >
+        ) => {
+            const newSearch: FavoriteCity = {
+            ...city,
+            id: `${city.lat}-${city.lon}-${Date.now()}`,
+            addedAt: Date.now(),
+        };
+
+        const exits = favorites.some((fav) => fav.id === newFavorites.id)
+        if (exits) return favorites;
+
+        const newFavorites = [...favorites, newFavorites].slice(0, 10);
+
+        setFavorites(newFavorites);
+        return newFavorites;
+    } ,
+    onSuccess:()=> {
+        queryClient.invalidateQueries({
+            queryKey: ["favorites"]
+        })
+    },
+   })
+
+   const removeFavorite = useMutation({
+    mutationFn: async (cityId:string) => {
+        const newFavorites = favorites.filter((city) => city.id !== cityId)
+        setFavorites(newFavorites)
+        return newFavorites;
+    },
+
+onSuccess: () => {
+      queryClient.invalidateQueries( {
+        queryKey: ["favorites"]
+      });
+    },
+  });
+
+
+  return {
+    favorites : favoritesQuery.data,
+    addFavorites,
+    removeFavorite,
+    isFavorite:(lat:number, lon:number) => 
+        favorites.some((city) => city.lat === lat && city.lon === lon )
+  };
+}

--- a/src/hooks/use-search-history.ts
+++ b/src/hooks/use-search-history.ts
@@ -17,7 +17,7 @@ export function useSearchHistory() {
    const [history, setHistory] =  useLocalStorege<SearchHistoryItem[]>("search-history", []);
 
    const historyQuery =  useQuery({
-    queryKey: ["search-histiry"],
+    queryKey: ["search-history"],
     queryFn: () => history,
     initialData: history,
    });
@@ -26,7 +26,7 @@ export function useSearchHistory() {
    const queryClient = useQueryClient();
    const addToHistory = useMutation( {
         mutationFn: async (
-            search: Omit<SearchHistoryItem, "Id" | "SearchedAt" >
+            search: Omit<SearchHistoryItem, "id" | "searchedAt" >
         ) => {
             const newSearch: SearchHistoryItem = {
             ...search,
@@ -54,8 +54,16 @@ export function useSearchHistory() {
         return [];
     },
 
+onSuccess: () => {
+      queryClient.setQueryData(["search-history"], []);
+    },
+  });
 
-   })
 
-   
+  return {
+    history,
+    addToHistory,
+    clearHistory,
+    historyQuery,
+  };
 }

--- a/src/pages/city-page.tsx
+++ b/src/pages/city-page.tsx
@@ -1,10 +1,62 @@
-
-import React from 'react'
+import CurrentWeather from "@/components/current-weather";
+import HourlyTemprature from "@/components/hourly-temprature";
+import WeatherSkeleton from "@/components/loading-skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import WeatherDetails from "@/components/weather-details";
+import WeatherForecast from "@/components/weather-forecast";
+import { useForecastQuery, useWeatherQuery } from "@/hooks/use-weather";
+import { AlertTriangle } from "lucide-react";
+import { useParams, useSearchParams } from "react-router-dom";
 
 const CityPage = () => {
-  return (
-    <div>City-page</div>
-  )
-}
+  const [searchParams] = useSearchParams();
+  const params = useParams();
+  const lat = parseFloat(searchParams.get("lat") || "0");
+  const lon = parseFloat(searchParams.get("lon") || "0");
 
-export default CityPage
+  const coordinates = { lat, lon };
+
+  const weatherQuery = useWeatherQuery(coordinates);
+  const forecastQuery = useForecastQuery(coordinates);
+
+  if (weatherQuery.error || forecastQuery.error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription className="flex flex-col gap-4">
+          failed to load weather data. Please try again.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!weatherQuery.data || !forecastQuery.data || !params.cityName) {
+    return <WeatherSkeleton />;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold tracking-tight">{params.cityName}, {weatherQuery.data.sys.country} </h1>
+        {/* <div>fav button</div> */}
+      </div>
+
+      {/* Weather info */}
+      <div className="grid gap-6">
+        <div className="flex flex-col  gap-4">
+          <CurrentWeather data={weatherQuery.data} />
+          {/* TODO: Forecast cards, hourly weather, etc */}
+          <HourlyTemprature data={forecastQuery.data} />
+        </div>
+        <div className="grid gap-5 md:grid-cols-2 items-start">
+          <WeatherDetails data={weatherQuery.data} />
+          <WeatherForecast data={forecastQuery.data} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CityPage;

--- a/src/pages/weather-dashboard.tsx
+++ b/src/pages/weather-dashboard.tsx
@@ -115,7 +115,8 @@ const WeatherDashboard = () => {
   const location = locationQuery.data?.[0]
   const locationName = locationQuery.data?.[0]?.name || "Unknown Location";
 
-  return (
+  return ( 
+
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
@@ -149,6 +150,7 @@ const WeatherDashboard = () => {
      </div>
       </div>
     </div>
+    
   );
 };
 


### PR DESCRIPTION
## Summary
This PR introduces a dedicated city details page to the weather application.
Users can now view extended weather information for a selected city.

## Changes
- Created `feature/city-page` branch.
- Added new `city-page.tsx` component for searching cities.
- Integrated widget into `weather-dashboard.tsx`.
- Updated `use-weather.ts` hook to handle search input.

## Testing
1. Run `npm start`.
2. Enter a city name in the search widget.
3. Verify that weather details update correctly.
